### PR TITLE
properly handle optional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+* The object type is now optional. When the `objectType` key is omitted while an
+  object is deserialized, it is to be assumed that the type of the denormalized
+  object is activity.
+
+* Empty PHP arrays are now dumped as JSON objects instead of empty lists.
+
 * fixed the key of the mbox SHA1 sum property when denormalizing actors
 
 * fixed deserializing incomplete agent objects that are missing the required

--- a/src/Normalizer/FilterNullValueNormalizer.php
+++ b/src/Normalizer/FilterNullValueNormalizer.php
@@ -36,7 +36,7 @@ class FilterNullValueNormalizer implements NormalizerInterface, SerializerAwareI
     public function normalize($object, $format = null, array $context = array())
     {
         $data = $this->normalizer->normalize($object, $format, $context);
-        $filteredData = array();
+        $filteredData = new \ArrayObject();
 
         foreach ($data as $key => $value) {
             if (null !== $value) {

--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -73,7 +73,7 @@ final class ObjectNormalizer extends Normalizer
      */
     public function denormalize($data, $class, $format = null, array $context = array())
     {
-        if (isset($data['objectType']) && 'Activity' === $data['objectType']) {
+        if (!isset($data['objectType']) || 'Activity' === $data['objectType']) {
             return $this->denormalizeActivity($data, $format, $context);
         }
 

--- a/tests/Integration/SerializerTest.php
+++ b/tests/Integration/SerializerTest.php
@@ -1,0 +1,255 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\XApi\Serializer\Tests\Integration;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Xabbuh\XApi\Model\Activity;
+use Xabbuh\XApi\Model\Actor;
+use Xabbuh\XApi\Model\Definition;
+use Xabbuh\XApi\Model\Result;
+use Xabbuh\XApi\Model\Score;
+use Xabbuh\XApi\Model\Verb;
+use Xabbuh\XApi\Serializer\Serializer;
+
+class SerializerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    protected function setUp()
+    {
+        $this->serializer = Serializer::createSerializer();
+    }
+
+    /**
+     * @dataProvider serializeActorData
+     */
+    public function testSerializeActor(Actor $actor, $expectedJson)
+    {
+        $this->assertJsonStringEqualsJsonString($expectedJson, $this->serializer->serialize($actor, 'json'));
+    }
+
+    public function serializeActorData()
+    {
+        return $this->buildSerializeTestCases('Actor');
+    }
+
+    /**
+     * @dataProvider deserializeActorData
+     */
+    public function testDeserializeActor($json, Actor $expectedActor)
+    {
+        $actor = $this->serializer->deserialize($json, 'Xabbuh\XApi\Model\Actor', 'json');
+
+        $this->assertInstanceOf('Xabbuh\XApi\Model\Actor', $actor);
+        $this->assertTrue($expectedActor->equals($actor), 'Deserialized actor has the expected properties');
+    }
+
+    public function deserializeActorData()
+    {
+        return $this->buildDeserializeTestCases('Actor');
+    }
+
+    /**
+     * @dataProvider serializeActivityData
+     */
+    public function testSerializeActivity(Activity $activity, $expectedJson)
+    {
+        $this->assertJsonStringEqualsJsonString($expectedJson, $this->serializer->serialize($activity, 'json'));
+    }
+
+    public function serializeActivityData()
+    {
+        return $this->buildSerializeTestCases('Activity');
+    }
+
+    /**
+     * @dataProvider deserializeActivityData
+     */
+    public function testDeserializeActivity($json, Activity $expectedActivity)
+    {
+        $activity = $this->serializer->deserialize($json, 'Xabbuh\XApi\Model\Object', 'json');
+
+        $this->assertInstanceOf('Xabbuh\XApi\Model\Activity', $activity);
+        $this->assertTrue($expectedActivity->equals($activity), 'Deserialized activity has the expected properties');
+    }
+
+    public function deserializeActivityData()
+    {
+        return $this->buildDeserializeTestCases('Activity');
+    }
+
+    /**
+     * @dataProvider serializeDefinitionData
+     */
+    public function testSerializeDefinition(Definition $definition, $expectedJson)
+    {
+        $this->assertJsonStringEqualsJsonString($expectedJson, $this->serializer->serialize($definition, 'json'));
+    }
+
+    public function serializeDefinitionData()
+    {
+        return $this->buildSerializeTestCases('Definition');
+    }
+
+    /**
+     * @dataProvider deserializeDefinitionData
+     */
+    public function testDeserializeDefinition($json, Definition $expectedDefinition)
+    {
+        $definition = $this->serializer->deserialize($json, 'Xabbuh\XApi\Model\Definition', 'json');
+
+        $this->assertInstanceOf('Xabbuh\XApi\Model\Definition', $definition);
+        $this->assertTrue($expectedDefinition->equals($definition), 'Deserialized definition has the expected properties');
+    }
+
+    public function deserializeDefinitionData()
+    {
+        return $this->buildDeserializeTestCases('Definition');
+    }
+
+    /**
+     * @dataProvider serializeResultData
+     */
+    public function testSerializeResult(Result $result, $expectedJson)
+    {
+        $this->assertJsonStringEqualsJsonString($expectedJson, $this->serializer->serialize($result, 'json'));
+    }
+
+    public function serializeResultData()
+    {
+        return $this->buildSerializeTestCases('Result');
+    }
+
+    /**
+     * @dataProvider deserializeResultData
+     */
+    public function testDeserializeResult($json, Result $expectedResult)
+    {
+        $result = $this->serializer->deserialize($json, 'Xabbuh\XApi\Model\Result', 'json');
+
+        $this->assertInstanceOf('Xabbuh\XApi\Model\Result', $result);
+        $this->assertTrue($expectedResult->equals($result), 'Deserialized result has the expected properties');
+    }
+
+    public function deserializeResultData()
+    {
+        return $this->buildDeserializeTestCases('Result');
+    }
+
+    /**
+     * @dataProvider serializeScoreData
+     */
+    public function testSerializeScore(Score $score, $expectedJson)
+    {
+        $this->assertJsonStringEqualsJsonString($expectedJson, $this->serializer->serialize($score, 'json'));
+    }
+
+    public function serializeScoreData()
+    {
+        return $this->buildSerializeTestCases('Score');
+    }
+
+    /**
+     * @dataProvider deserializeScoreData
+     */
+    public function testDeserializeScore($json, Score $expectedScore)
+    {
+        $score = $this->serializer->deserialize($json, 'Xabbuh\XApi\Model\Score', 'json');
+
+        $this->assertInstanceOf('Xabbuh\XApi\Model\Score', $score);
+        $this->assertTrue($expectedScore->equals($score), 'Deserialized score has the expected properties');
+    }
+
+    public function deserializeScoreData()
+    {
+        return $this->buildDeserializeTestCases('Score');
+    }
+
+    /**
+     * @dataProvider serializeVerbData
+     */
+    public function testSerializeVerb(Verb $verb, $expectedJson)
+    {
+        $this->assertJsonStringEqualsJsonString($expectedJson, $this->serializer->serialize($verb, 'json'));
+    }
+
+    public function serializeVerbData()
+    {
+        return $this->buildSerializeTestCases('Verb');
+    }
+
+    /**
+     * @dataProvider deserializeVerbData
+     */
+    public function testDeserializeVerb($json, Verb $expectedVerb)
+    {
+        $verb = $this->serializer->deserialize($json, 'Xabbuh\XApi\Model\Verb', 'json');
+
+        $this->assertInstanceOf('Xabbuh\XApi\Model\Verb', $verb);
+        $this->assertTrue($expectedVerb->equals($verb), 'Deserialized verb has the expected properties');
+    }
+
+    public function deserializeVerbData()
+    {
+        return $this->buildDeserializeTestCases('Verb');
+    }
+
+    private function buildSerializeTestCases($objectType)
+    {
+        $tests = array();
+
+        $phpFixturesClass = 'Xabbuh\XApi\DataFixtures\\'.$objectType.'Fixtures';
+        $jsonFixturesClass = 'XApi\Fixtures\Json\\'.$objectType.'JsonFixtures';
+        $jsonFixturesMethods = get_class_methods($jsonFixturesClass);
+
+        foreach (get_class_methods($phpFixturesClass) as $method) {
+            // serialized data will always contain type information
+            if (in_array($method.'WithType', $jsonFixturesMethods)) {
+                $jsonMethod = $method.'WithType';
+            } else {
+                $jsonMethod = $method;
+            }
+
+            $tests[$method] = array(
+                call_user_func(array($phpFixturesClass, $method)),
+                call_user_func(array($jsonFixturesClass, $jsonMethod)),
+            );
+        }
+
+        return $tests;
+    }
+
+    private function buildDeserializeTestCases($objectType)
+    {
+        $tests = array();
+
+        $jsonFixturesClass = 'XApi\Fixtures\Json\\'.$objectType.'JsonFixtures';
+        $phpFixturesClass = 'Xabbuh\XApi\DataFixtures\\'.$objectType.'Fixtures';
+
+        foreach (get_class_methods($jsonFixturesClass) as $method) {
+            // PHP objects do not contain the type information as a dedicated property
+            if ('WithType' === substr($method, -8)) {
+                continue;
+            }
+
+            $tests[$method] = array(
+                call_user_func(array($jsonFixturesClass, $method)),
+                call_user_func(array($phpFixturesClass, $method)),
+            );
+        }
+
+        return $tests;
+    }
+}


### PR DESCRIPTION
- The object type is optional. When the objectType key is omitted in the
  serialized data, it is to be assumed that the object type is activity.
- Empty PHP arrays must be dumped as JSON objects instead of empty
  lists.
