### PR TITLE
reflect the removal of sub statement ids

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "php-xapi/json-test-fixtures": "^0.2.3@dev",
-        "php-xapi/test-fixtures": "^0.4.1@dev",
+        "php-xapi/test-fixtures": "^0.5.0@dev",
         "phpspec/phpspec": "~2.0"
     },
     "conflict": {

--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -138,6 +138,6 @@ final class ObjectNormalizer extends Normalizer
             $statementContext = $this->denormalizeData($data['context'], 'Xabbuh\XApi\Model\Context', $format, $context);
         }
 
-        return new SubStatement(null, $actor, $verb, $object, $result, $statementContext);
+        return new SubStatement($actor, $verb, $object, $result, $statementContext);
     }
 }


### PR DESCRIPTION
This brings the test fixtures in sync with the latest changes from the
model package where the id has been removed from the SubStatement class.
